### PR TITLE
Add a requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+click==6.7
+Flask==0.12.2
+itsdangerous==0.24
+Jinja2==2.10
+MarkupSafe==1.0
+psycopg2==2.7.3.2
+Werkzeug==0.14.1


### PR DESCRIPTION
Add a requirements file to allow automatically installing dependencies. Note: this list was derived from only the postgres example. 