### PR TITLE
Fix FLASK_APP file name

### DIFF
--- a/example-postgresql/README.md
+++ b/example-postgresql/README.md
@@ -12,4 +12,4 @@ The connection string provided by your Compose PostgreSQL deployment should go i
 Download a copy of the certificate and put it's path in an environment variable `PATH_TO_POSTGRESQL_CERT`.
 
 #### Running the Application
-To run the app from the command-line, set and environment variable `FLASK_APP=postgresql-example.py`, and use the `flask run` command in the same directory as the python file.
+To run the app from the command-line, set and environment variable `FLASK_APP=postgresql_example.py`, and use the `flask run` command in the same directory as the python file.


### PR DESCRIPTION
The FLASK_APP file name was wrong. This commit fixes it. 